### PR TITLE
Enhance web search to extract images

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -99,7 +99,18 @@ def extract_metadata(soup, url):
         metadata["description"] = description.get("content", "No description found.")
     if html := soup.find("html"):
         metadata["language"] = html.get("lang", "No language found.")
+    metadata["images"] = extract_images(soup, url)
     return metadata
+
+
+def extract_images(soup, base_url):
+    images = []
+    for img in soup.find_all("img"):
+        src = img.get("src")
+        if not src:
+            continue
+        images.append(urllib.parse.urljoin(base_url, src))
+    return images
 
 
 def verify_ssl_cert(url: str) -> bool:

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1972,6 +1972,11 @@ async def process_web_search(
             doc.metadata.get("source") for doc in docs if doc.metadata.get("source")
         ]  # only keep the urls returned by the loader
 
+        images = []
+        for doc in docs:
+            images.extend(doc.metadata.get("images", []))
+        images = list(dict.fromkeys(images))
+
         if request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:
             return {
                 "status": True,
@@ -1985,6 +1990,7 @@ async def process_web_search(
                     for doc in docs
                 ],
                 "loaded_count": len(docs),
+                "images": images,
             }
         else:
             # Create a single collection for all documents
@@ -2011,6 +2017,7 @@ async def process_web_search(
                 "collection_names": [collection_name],
                 "filenames": urls,
                 "loaded_count": len(docs),
+                "images": images,
             }
     except Exception as e:
         log.exception(e)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -440,6 +440,7 @@ async def chat_web_search_handler(
                             "type": "web_search",
                             "urls": results["filenames"],
                             "queries": queries,
+                            "images": results.get("images", []),
                         }
                     )
             elif results.get("docs"):
@@ -452,8 +453,12 @@ async def chat_web_search_handler(
                         "type": "web_search",
                         "urls": results["filenames"],
                         "queries": queries,
+                        "images": results.get("images", []),
                     }
                 )
+
+            for img in results.get("images", []):
+                files.append({"type": "image", "url": img})
 
             form_data["files"] = files
 


### PR DESCRIPTION
## Summary
- add `extract_images` helper to parse image sources from scraped pages
- capture image URLs in web search results
- return and forward images through middleware so they're shown in chat

## Testing
- `npm run lint:backend` *(fails: Your code has been rated at 6.18/10)*
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*
- `npm run lint:types` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b036261548323be3e3d848f8adb6f