### PR TITLE
Fix telemetry error and show search images

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -50,6 +50,7 @@ langchain==0.3.26
 langchain-community==0.3.26
 
 fake-useragent==2.1.0
+posthog==3.8.3
 chromadb==0.6.3
 pymilvus==2.5.0
 qdrant-client==1.14.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "langchain-community==0.3.26",
 
     "fake-useragent==2.1.0",
+    "posthog==3.8.3",
     "chromadb==0.6.3",
     "pymilvus==2.5.0",
     "qdrant-client==1.14.3",

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -290,9 +290,10 @@ export const updateRerankingConfig = async (token: string, payload: RerankingMod
 };
 
 export interface SearchDocument {
-	status: boolean;
-	collection_name: string;
-	filenames: string[];
+        status: boolean;
+        collection_name: string;
+        filenames: string[];
+        images: string[];
 }
 
 export const processFile = async (

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -706,26 +706,36 @@
 							{/if}
 						{/if}
 
-						{#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}
-							<div class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap">
-								{#each message.files as file}
-									<div>
-										{#if file.type === 'image'}
-											<Image src={file.url} alt={message.content} />
-										{:else}
-											<FileItem
-												item={file}
-												url={file.url}
-												name={file.name}
-												type={file.type}
-												size={file?.size}
-												colorClassName="bg-white dark:bg-gray-850 "
-											/>
-										{/if}
-									</div>
-								{/each}
-							</div>
-						{/if}
+                                                {#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}
+                                                        <div class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap">
+                                                                {#each message.files as file}
+                                                                        <div>
+                                                                                {#if file.type === 'image'}
+                                                                                        <Image src={file.url} alt={message.content} />
+                                                                                {:else}
+                                                                                        <FileItem
+                                                                                                item={file}
+                                                                                                url={file.url}
+                                                                                                name={file.name}
+                                                                                                type={file.type}
+                                                                                                size={file?.size}
+                                                                                                colorClassName="bg-white dark:bg-gray-850 "
+                                                                                        />
+                                                                                {/if}
+                                                                        </div>
+                                                                {/each}
+                                                        </div>
+                                                {/if}
+
+                                                {#if message?.files && message.files?.filter((f) => f.type === 'web_search' && f.images?.length > 0).length > 0}
+                                                        <div class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap">
+                                                                {#each message.files.filter((f) => f.type === 'web_search' && f.images?.length > 0) as file}
+                                                                        {#each file.images as img}
+                                                                                <Image src={img} alt={message.content} />
+                                                                        {/each}
+                                                                {/each}
+                                                        </div>
+                                                {/if}
 
 						{#if edit === true}
 							<div class="w-full bg-gray-50 dark:bg-gray-800 rounded-3xl px-5 py-3 my-2">


### PR DESCRIPTION
## Summary
- fix chromadb telemetry by adding PostHog dependency
- extend search API response type to include images
- render images from search results in chat UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_docker')*

------
https://chatgpt.com/codex/tasks/task_e_687b096dfbc883238ef2f690f61a3102