### PR TITLE
Add web search snippet support

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2006,6 +2006,14 @@ async def process_web_search(
             doc.metadata.get("source") for doc in docs if doc.metadata.get("source")
         ]  # only keep the urls returned by the loader
 
+        snippets = []
+        for doc in docs:
+            snippet = doc.metadata.get("snippet") or doc.metadata.get("description")
+            if snippet:
+                snippets.append(snippet)
+            else:
+                snippets.append("")
+
         images = images_from_search.copy()
         for doc in docs:
             images.extend(doc.metadata.get("images", []))
@@ -2025,6 +2033,7 @@ async def process_web_search(
                 ],
                 "loaded_count": len(docs),
                 "images": images,
+                "snippets": snippets,
             }
         else:
             # Create a single collection for all documents
@@ -2052,6 +2061,7 @@ async def process_web_search(
                 "filenames": urls,
                 "loaded_count": len(docs),
                 "images": images,
+                "snippets": snippets,
             }
     except Exception as e:
         log.exception(e)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -471,6 +471,7 @@ async def chat_web_search_handler(
                         "description": "Searched {{count}} sites",
                         "urls": results["filenames"],
                         "images": results.get("images", []),
+                        "snippets": results.get("snippets", []),
                         "query": ", ".join(queries),
                         "done": True,
                     },

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -294,6 +294,7 @@ export interface SearchDocument {
         collection_name: string;
         filenames: string[];
         images: string[];
+        snippets: string[];
 }
 
 export const processFile = async (

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -65,6 +65,7 @@
                         description: string;
                         urls?: string[];
                         images?: string[];
+                        snippets?: string[];
                         query?: string;
                 }[];
                 status?: {
@@ -73,6 +74,7 @@
                         description: string;
                         urls?: string[];
                         images?: string[];
+                        snippets?: string[];
                         query?: string;
                 };
 		done: boolean;

--- a/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
@@ -5,7 +5,7 @@
         import Collapsible from '$lib/components/common/Collapsible.svelte';
         import Image from '$lib/components/common/Image.svelte';
 
-        export let status = { urls: [], images: [], query: '' };
+       export let status = { urls: [], images: [], snippets: [], query: '' };
 	let state = false;
 </script>
 
@@ -59,37 +59,41 @@
 			</a>
 		{/if}
 
-                {#each status.urls as url, urlIdx}
-			<a
-				href={url}
-				target="_blank"
-				class="flex w-full items-center p-3 px-4 {urlIdx === status.urls.length - 1
-					? ''
-					: 'border-b border-gray-300/30 dark:border-gray-700/50'} group/item justify-between font-normal text-gray-800 dark:text-gray-300"
-			>
-				<div class=" line-clamp-1">
-					{url}
-				</div>
+               {#each status.urls as url, urlIdx}
+                       <div class="border-b border-gray-300/30 dark:border-gray-700/50 last:border-b-0">
+                               <a
+                                       href={url}
+                                       target="_blank"
+                                       class="flex w-full items-center p-3 px-4 group/item justify-between font-normal text-gray-800 dark:text-gray-300"
+                               >
+                                       <div class=" line-clamp-1">
+                                               {url}
+                                       </div>
 
-				<div
-					class=" ml-1 text-white dark:text-gray-900 group-hover/item:text-gray-600 dark:group-hover/item:text-white transition"
-				>
-					<!--  -->
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 16 16"
-						fill="currentColor"
-						class="size-4"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M4.22 11.78a.75.75 0 0 1 0-1.06L9.44 5.5H5.75a.75.75 0 0 1 0-1.5h5.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-1.5 0V6.56l-5.22 5.22a.75.75 0 0 1-1.06 0Z"
-							clip-rule="evenodd"
-						/>
-					</svg>
-				</div>
-			</a>
-                {/each}
+                                       <div
+                                               class=" ml-1 text-white dark:text-gray-900 group-hover/item:text-gray-600 dark:group-hover/item:text-white transition"
+                                       >
+                                               <svg
+                                                       xmlns="http://www.w3.org/2000/svg"
+                                                       viewBox="0 0 16 16"
+                                                       fill="currentColor"
+                                                       class="size-4"
+                                               >
+                                                       <path
+                                                               fill-rule="evenodd"
+                                                               d="M4.22 11.78a.75.75 0 0 1 0-1.06L9.44 5.5H5.75a.75.75 0 0 1 0-1.5h5.5a.75.75 0 0 1 .75.75v5.5a.75.75 0 0 1-1.5 0V6.56l-5.22 5.22a.75.75 0 0 1-1.06 0Z"
+                                                               clip-rule="evenodd"
+                                                       />
+                                               </svg>
+                                       </div>
+                               </a>
+                               {#if status.snippets && status.snippets[urlIdx]}
+                                       <div class="px-4 pb-3 text-gray-600 dark:text-gray-400 text-wrap">
+                                               {status.snippets[urlIdx]}
+                                       </div>
+                               {/if}
+                       </div>
+               {/each}
                 {#if status.images && status.images.length > 0}
                         <div class="flex overflow-x-auto gap-2 p-3 px-4 border-t border-gray-300/30 dark:border-gray-700/50">
                                 {#each status.images as img}


### PR DESCRIPTION
## Summary
- extend `WebSearchResults` component to show snippet under each link
- send snippet info from backend search utilities
- expose snippet data in chat status history objects and types

## Testing
- `node --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b301f2d0883239f918baacac8c01a