### PR TITLE
Enhance personalization and search features

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2498,6 +2498,12 @@ WEB_SEARCH_TRUST_ENV = PersistentConfig(
     os.getenv("WEB_SEARCH_TRUST_ENV", "False").lower() == "true",
 )
 
+DDG_SAFESEARCH = PersistentConfig(
+    "DDG_SAFESEARCH",
+    "rag.web.search.ddg_safesearch",
+    os.getenv("DDG_SAFESEARCH", "moderate"),
+)
+
 
 SEARXNG_QUERY_URL = PersistentConfig(
     "SEARXNG_QUERY_URL",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -451,6 +451,11 @@ from open_webui.utils.plugin import install_tool_and_function_dependencies
 from open_webui.utils.oauth import OAuthManager
 from open_webui.utils.security_headers import SecurityHeadersMiddleware
 from open_webui.utils.redis import get_redis_connection
+from open_webui.models.chats import Chats
+from open_webui.models.users import Users
+from open_webui.models.memories import Memories
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
 from open_webui.tasks import (
     redis_task_command_listener,
@@ -469,6 +474,64 @@ if SAFE_MODE:
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])
+
+
+async def periodic_chat_summarization(app: FastAPI):
+    while True:
+        await asyncio.sleep(86400)
+        users_data = Users.get_users()
+        users = users_data.get("users", []) if isinstance(users_data, dict) else []
+        for u in users:
+            chats = Chats.get_chats_by_user_id(u.id)
+            for chat in chats:
+                messages = chat.chat.get("messages", [])
+                if not messages:
+                    continue
+                text = "\n".join([f"{m.get('role')}: {m.get('content')}" for m in messages])
+                prompt = f"Summarize the following conversation in a short paragraph:\n{text}"
+                model_id = app.state.config.TASK_MODEL or list(app.state.MODELS.keys())[0]
+                payload = {
+                    "model": model_id,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                }
+                req = Request(
+                    {
+                        "type": "http",
+                        "asgi.version": "3.0",
+                        "asgi.spec_version": "2.0",
+                        "method": "POST",
+                        "path": "/internal",
+                        "query_string": b"",
+                        "headers": Headers({}).raw,
+                        "client": ("127.0.0.1", 0),
+                        "server": ("127.0.0.1", 80),
+                        "scheme": "http",
+                        "app": app,
+                    }
+                )
+                try:
+                    res = await generate_chat_completion(req, form_data=payload, user=u)
+                    summary = res.get("choices", [{}])[0].get("message", {}).get("content", "")
+                    if summary:
+                        memory = Memories.insert_new_memory(
+                            u.id,
+                            summary,
+                            {"type": "chat_summary", "chat_id": chat.id},
+                        )
+                        VECTOR_DB_CLIENT.upsert(
+                            collection_name=f"user-memory-{u.id}",
+                            items=[
+                                {
+                                    "id": memory.id,
+                                    "text": memory.content,
+                                    "vector": app.state.EMBEDDING_FUNCTION(memory.content, user=u),
+                                    "metadata": {"created_at": memory.created_at, "tags": ["summary"]},
+                                }
+                            ],
+                        )
+                except Exception as e:
+                    log.error(f"summary job error: {e}")
 
 
 class SPAStaticFiles(StaticFiles):
@@ -537,6 +600,7 @@ async def lifespan(app: FastAPI):
         limiter.total_tokens = THREAD_POOL_SIZE
 
     asyncio.create_task(periodic_usage_pool_cleanup())
+    asyncio.create_task(periodic_chat_summarization(app))
 
     if app.state.config.ENABLE_BASE_MODELS_CACHE:
         await get_all_models(

--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -5,13 +5,15 @@ from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from ddgs import DDGS
 from ddgs.exceptions import RatelimitException
 from open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import DDG_SAFESEARCH
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
 
 
 def search_duckduckgo(
-    query: str, count: int, filter_list: Optional[list[str]] = None
+    query: str, count: int, filter_list: Optional[list[str]] = None,
+    safesearch: str = DDG_SAFESEARCH.value,
 ) -> list[SearchResult]:
     """
     Search using DuckDuckGo's Search API and return the results as a list of SearchResult objects.
@@ -28,7 +30,7 @@ def search_duckduckgo(
         # Use the ddgs.text() method to perform the search
         try:
             search_results = ddgs.text(
-                query, safesearch="moderate", max_results=count, backend="lite"
+                query, safesearch=safesearch, max_results=count, backend="lite"
             )
         except RatelimitException as e:
             log.error(f"RatelimitException: {e}")
@@ -46,12 +48,12 @@ def search_duckduckgo(
     ]
 
 
-def search_duckduckgo_images(query: str, count: int) -> List[str]:
+def search_duckduckgo_images(query: str, count: int, safesearch: str = DDG_SAFESEARCH.value) -> List[str]:
     """Return image URLs from DuckDuckGo image search."""
     images = []
     with DDGS() as ddgs:
         try:
-            for result in ddgs.images(query, safesearch="moderate", max_results=count):
+            for result in ddgs.images(query, safesearch=safesearch, max_results=count):
                 url = result.get("image") or result.get("thumbnail")
                 if url:
                     images.append(url)

--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { onMount, getContext } from 'svelte';
+import { getFiles } from '$lib/apis/files';
+import { user } from '$lib/stores';
+
+let images: any[] = [];
+const i18n = getContext('i18n');
+
+onMount(async () => {
+    const token = $user?.token ?? '';
+    try {
+        const files = await getFiles(token);
+        images = files.filter((f: any) => f.meta?.content_type?.startsWith('image/'));
+    } catch (e) {
+        console.error('failed to load gallery', e);
+    }
+});
+</script>
+
+<div class="p-4 grid grid-cols-2 md:grid-cols-3 gap-2">
+    {#each images as img}
+        <img class="w-full rounded" src={`/api/files/${img.id}/content`} alt={img.filename} />
+    {/each}
+</div>


### PR DESCRIPTION
## Summary
- allow tagging memory items via new meta field
- add chat summarization endpoint storing summaries as memories
- persist DuckDuckGo safesearch setting from environment
- save web image results as Files and provide Gallery component
- add periodic background job to summarize chats

## Testing
- `python -m py_compile backend/open_webui/models/memories.py backend/open_webui/routers/memories.py backend/open_webui/routers/chats.py backend/open_webui/retrieval/web/duckduckgo.py backend/open_webui/routers/retrieval.py backend/open_webui/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687b3493d21c83239b148f319ee955dd